### PR TITLE
fix: implement NonBreakingSpace rendering and fix Escape output ordering

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -349,7 +349,9 @@ impl<'a> Writer<'a> {
                                     width += 2;
                                     self.prefix.push(" ".repeat(width).to_string());
                                 }
-                                jotdown::ListKind::Task(list_bullet_type) => todo!(),
+                                jotdown::ListKind::Task(_) => unreachable!(
+                                    "task list items use TaskListItem container, not ListItem"
+                                ),
                             }
                         }
                         jotdown::Container::TaskListItem { checked } => {
@@ -759,7 +761,9 @@ impl<'a> Writer<'a> {
                 jotdown::Event::Ellipsis => self.push_word("...")?,
                 jotdown::Event::EnDash => self.push_word("--")?,
                 jotdown::Event::EmDash => self.push_word("---")?,
-                jotdown::Event::NonBreakingSpace => todo!(),
+                jotdown::Event::NonBreakingSpace => {
+                    self.push_word(" ")?;
+                }
                 jotdown::Event::Softbreak => {
                     self.commit_word(false, &mut out)?;
                     self.wrap(&mut out)?;
@@ -768,7 +772,7 @@ impl<'a> Writer<'a> {
                     self.commit_word(false, &mut out)?;
                     self.wrap(&mut out)?;
                 }
-                jotdown::Event::Escape => out.write_str("\\")?,
+                jotdown::Event::Escape => self.push_word("\\")?,
                 jotdown::Event::Blankline => {
                     self.blankline(&mut out)?;
                 }

--- a/tests/nonbreaking-space.in
+++ b/tests/nonbreaking-space.in
@@ -1,0 +1,1 @@
+no\ break

--- a/tests/nonbreaking-space.out
+++ b/tests/nonbreaking-space.out
@@ -1,0 +1,1 @@
+no\ break


### PR DESCRIPTION
- Replace `todo!()` for `Event::NonBreakingSpace` with a space character
  output (the preceding `Event::Escape` already emits the backslash).
- Fix `Event::Escape` to use `push_word("\\")` instead of directly writing
  to `out`, which caused output reordering when pending words existed.
- Replace `todo!()` for `ListKind::Task` in ListItem with `unreachable!()`
  since task list items use the `TaskListItem` container.
- Add integration test for nonbreaking space (`no\ break`).

This commit message is generated by LLM, it might be wrong.

Co-Authored-By: Claude Code (glm-5.1) <noreply@anthropic.com>
