### PR TITLE
test: switch to runtime test discovery for integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,14 +139,12 @@ dependencies = [
  "clap",
  "colog",
  "env_logger",
+ "glob",
  "jotdown",
  "log",
- "paste",
  "pretty_assertions",
  "roman",
- "test_each_file",
  "unicode-width",
- "walkdir",
 ]
 
 [[package]]
@@ -171,6 +169,12 @@ dependencies = [
  "jiff",
  "log",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "heck"
@@ -223,12 +227,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "portable-atomic"
@@ -309,15 +307,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2c543f0c827ae24df93159810fd4bce2d0abe3785bb4c4d68fae3c467d58d9b"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,18 +344,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "test_each_file"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44619e49a1f62888c271dc50533f036363a7936f99c7cb467ca9d45224cf83b3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-ident",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,25 +360,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ colog = "1.4.0"
 env_logger = "0.11.10"
 jotdown = "0.9.1"
 log = "0.4.29"
-paste = "1.0.15"
-pretty_assertions = "1.4.1"
 roman = "0.1.6"
-test_each_file = "0.3.7"
 unicode-width = "0.2.2"
-walkdir = "2.5.0"
+
+[dev-dependencies]
+glob = "0.3"
+pretty_assertions = "1.4.1"

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,46 +1,85 @@
 use djotfmt::WriterConfig;
 use pretty_assertions::assert_eq;
-use test_each_file::test_each_path;
 
-test_each_path! { for ["in", "out"] in "./tests/" => test }
+fn discover_tests(base: &str, extensions: &[&str]) -> Vec<Vec<std::path::PathBuf>> {
+    let base = std::path::Path::new(base);
+    let mut groups: std::collections::BTreeMap<String, Vec<std::path::PathBuf>> =
+        std::collections::BTreeMap::new();
 
-fn test([input_path, expected]: [&std::path::Path; 2]) {
-    let input = std::fs::read_to_string(input_path).unwrap();
-    let expected = std::fs::read_to_string(&expected).unwrap();
+    for ext in extensions {
+        let pattern = base.join(format!("*.{ext}"));
+        for entry in glob::glob(pattern.to_str().unwrap()).unwrap() {
+            let path = entry.unwrap();
+            let stem = path.file_stem().unwrap().to_str().unwrap().to_string();
+            groups.entry(stem).or_default().push(path);
+        }
+    }
 
-    let max_cols = parse_max_cols(&input);
-    let config = WriterConfig { max_cols };
-
-    let mut output = String::new();
-    djotfmt::Renderer::new(&input)
-        .push_offset(
-            jotdown::Parser::new(&input).into_offset_iter(),
-            &mut output,
-            &config,
-        )
-        .unwrap();
-
-    assert_eq!(output, expected);
+    groups
+        .into_values()
+        .filter(|paths| paths.len() == extensions.len())
+        .collect()
 }
 
-test_each_path! { for ["out"] in "./tests/" as idempotent => test_idempotent }
+#[test]
+fn test_all() {
+    let tests = discover_tests("./tests/", &["in", "out"]);
+    assert!(!tests.is_empty(), "no test cases found");
 
-fn test_idempotent([path]: [&std::path::Path; 1]) {
-    let input = std::fs::read_to_string(path).unwrap();
+    for paths in &tests {
+        let input_path = paths.iter().find(|p| p.extension().unwrap() == "in").unwrap();
+        let expected_path = paths.iter().find(|p| p.extension().unwrap() == "out").unwrap();
 
-    let max_cols = parse_max_cols(&input);
-    let config = WriterConfig { max_cols };
+        let input = std::fs::read_to_string(input_path).unwrap();
+        let expected = std::fs::read_to_string(expected_path).unwrap();
 
-    let mut output = String::new();
-    djotfmt::Renderer::new(&input)
-        .push_offset(
-            jotdown::Parser::new(&input).into_offset_iter(),
-            &mut output,
-            &config,
-        )
-        .unwrap();
+        let max_cols = parse_max_cols(&input);
+        let config = WriterConfig { max_cols };
 
-    assert_eq!(output, input);
+        let mut output = String::new();
+        djotfmt::Renderer::new(&input)
+            .push_offset(
+                jotdown::Parser::new(&input).into_offset_iter(),
+                &mut output,
+                &config,
+            )
+            .unwrap();
+
+        assert_eq!(
+            output, expected,
+            "test case {:?} failed",
+            input_path.file_stem().unwrap()
+        );
+    }
+}
+
+#[test]
+fn test_idempotent() {
+    let tests = discover_tests("./tests/", &["out"]);
+    assert!(!tests.is_empty(), "no test cases found");
+
+    for paths in &tests {
+        let path = &paths[0];
+        let input = std::fs::read_to_string(path).unwrap();
+
+        let max_cols = parse_max_cols(&input);
+        let config = WriterConfig { max_cols };
+
+        let mut output = String::new();
+        djotfmt::Renderer::new(&input)
+            .push_offset(
+                jotdown::Parser::new(&input).into_offset_iter(),
+                &mut output,
+                &config,
+            )
+            .unwrap();
+
+        assert_eq!(
+            output, input,
+            "idempotent test failed for {:?}",
+            path.file_stem().unwrap()
+        );
+    }
 }
 
 fn parse_max_cols(content: &str) -> usize {


### PR DESCRIPTION
Replace `test_each_file` proc-macro with runtime `glob`-based test
discovery. The proc-macro scans files at compile time, so adding new
.in/.out test cases required touching integration_test.rs to trigger a
recompile. With runtime discovery, new test files are picked up
immediately on the next `cargo test` run.

Move `glob` and `pretty_assertions` to [dev-dependencies]; remove
`test_each_file`, `paste`, and `walkdir` from dependencies.

This commit message is generated by LLM, it might be wrong.

Co-Authored-By: Claude Code (glm-5.1) <noreply@anthropic.com>
