### PR TITLE
test: use libtest_mimic to generate individual test per in/out file pair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,7 @@ dependencies = [
  "env_logger",
  "glob",
  "jotdown",
+ "libtest-mimic",
  "log",
  "pretty_assertions",
  "roman",
@@ -169,6 +170,12 @@ dependencies = [
  "jiff",
  "log",
 ]
+
+[[package]]
+name = "escape8259"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
 
 [[package]]
 name = "glob"
@@ -215,6 +222,18 @@ dependencies = [
 [[package]]
 name = "jotdown"
 version = "0.9.1"
+
+[[package]]
+name = "libtest-mimic"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14e6ba06f0ade6e504aff834d7c34298e5155c6baca353cc6a4aaff2f9fd7f33"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap",
+ "escape8259",
+]
 
 [[package]]
 name = "log"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,9 @@ unicode-width = "0.2.2"
 
 [dev-dependencies]
 glob = "0.3"
+libtest-mimic = "0.8"
 pretty_assertions = "1.4.1"
+
+[[test]]
+name = "integration_test"
+harness = false

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,4 +1,5 @@
 use djotfmt::WriterConfig;
+use libtest_mimic::{Arguments, Failed, Trial};
 use pretty_assertions::assert_eq;
 
 fn discover_tests(base: &str, extensions: &[&str]) -> Vec<Vec<std::path::PathBuf>> {
@@ -21,67 +22,6 @@ fn discover_tests(base: &str, extensions: &[&str]) -> Vec<Vec<std::path::PathBuf
         .collect()
 }
 
-#[test]
-fn test_all() {
-    let tests = discover_tests("./tests/", &["in", "out"]);
-    assert!(!tests.is_empty(), "no test cases found");
-
-    for paths in &tests {
-        let input_path = paths.iter().find(|p| p.extension().unwrap() == "in").unwrap();
-        let expected_path = paths.iter().find(|p| p.extension().unwrap() == "out").unwrap();
-
-        let input = std::fs::read_to_string(input_path).unwrap();
-        let expected = std::fs::read_to_string(expected_path).unwrap();
-
-        let max_cols = parse_max_cols(&input);
-        let config = WriterConfig { max_cols };
-
-        let mut output = String::new();
-        djotfmt::Renderer::new(&input)
-            .push_offset(
-                jotdown::Parser::new(&input).into_offset_iter(),
-                &mut output,
-                &config,
-            )
-            .unwrap();
-
-        assert_eq!(
-            output, expected,
-            "test case {:?} failed",
-            input_path.file_stem().unwrap()
-        );
-    }
-}
-
-#[test]
-fn test_idempotent() {
-    let tests = discover_tests("./tests/", &["out"]);
-    assert!(!tests.is_empty(), "no test cases found");
-
-    for paths in &tests {
-        let path = &paths[0];
-        let input = std::fs::read_to_string(path).unwrap();
-
-        let max_cols = parse_max_cols(&input);
-        let config = WriterConfig { max_cols };
-
-        let mut output = String::new();
-        djotfmt::Renderer::new(&input)
-            .push_offset(
-                jotdown::Parser::new(&input).into_offset_iter(),
-                &mut output,
-                &config,
-            )
-            .unwrap();
-
-        assert_eq!(
-            output, input,
-            "idempotent test failed for {:?}",
-            path.file_stem().unwrap()
-        );
-    }
-}
-
 fn parse_max_cols(content: &str) -> usize {
     let mut max_cols = 72;
     for line in content.lines() {
@@ -98,4 +38,90 @@ fn parse_max_cols(content: &str) -> usize {
         }
     }
     max_cols
+}
+
+fn run_format_test(
+    input_path: std::path::PathBuf,
+    expected_path: std::path::PathBuf,
+) -> Result<(), Failed> {
+    let input = std::fs::read_to_string(&input_path).map_err(|e| e.to_string())?;
+    let expected = std::fs::read_to_string(&expected_path).map_err(|e| e.to_string())?;
+
+    let max_cols = parse_max_cols(&input);
+    let config = WriterConfig { max_cols };
+
+    let mut output = String::new();
+    djotfmt::Renderer::new(&input)
+        .push_offset(
+            jotdown::Parser::new(&input).into_offset_iter(),
+            &mut output,
+            &config,
+        )
+        .unwrap();
+
+    assert_eq!(output, expected, "test case {:?}", input_path.file_stem().unwrap());
+    Ok(())
+}
+
+fn run_idempotent_test(path: std::path::PathBuf) -> Result<(), Failed> {
+    let input = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
+
+    let max_cols = parse_max_cols(&input);
+    let config = WriterConfig { max_cols };
+
+    let mut output = String::new();
+    djotfmt::Renderer::new(&input)
+        .push_offset(
+            jotdown::Parser::new(&input).into_offset_iter(),
+            &mut output,
+            &config,
+        )
+        .unwrap();
+
+    assert_eq!(output, input, "idempotent test failed for {:?}", path.file_stem().unwrap());
+    Ok(())
+}
+
+fn main() {
+    let args = Arguments::from_args();
+    let mut trials = Vec::new();
+
+    let tests = discover_tests("./tests/", &["in", "out"]);
+    assert!(!tests.is_empty(), "no test cases found");
+
+    for paths in &tests {
+        let input_path = paths
+            .iter()
+            .find(|p| p.extension().unwrap() == "in")
+            .unwrap()
+            .clone();
+        let expected_path = paths
+            .iter()
+            .find(|p| p.extension().unwrap() == "out")
+            .unwrap()
+            .clone();
+        let name = input_path
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        trials.push(Trial::test(name, move || {
+            run_format_test(input_path, expected_path)
+        }));
+    }
+
+    let idem_tests = discover_tests("./tests/", &["out"]);
+    assert!(!idem_tests.is_empty(), "no idempotent test cases found");
+
+    for paths in &idem_tests {
+        let path = paths[0].clone();
+        let stem = path.file_stem().unwrap().to_str().unwrap().to_string();
+        let name = format!("idempotent::{}", stem);
+
+        trials.push(Trial::test(name, move || run_idempotent_test(path)));
+    }
+
+    libtest_mimic::run(&args, trials).exit();
 }


### PR DESCRIPTION
Replace the single `test_all()` and `test_idempotent()` functions with
a custom test harness using `libtest_mimic`. Each `.in`/`.out` file pair
now appears as a separate test case in `cargo test` output, and can be
run individually with `cargo test <case-name>`. Idempotent tests are
prefixed with `idempotent::`.

Adding new test cases no longer requires editing Rust code — just create
a new `.in`/`.out` pair in the `tests/` directory.

This commit message is generated by LLM, it might be wrong.

Co-Authored-By: Claude Code (glm-5.1) <noreply@anthropic.com>
