### PR TITLE
tests

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1148,18 +1148,24 @@ impl<'a> Writer<'a> {
                             }
                         }
                     }
-                    self.push_word("}")?;
-                    self.commit_word(true, &mut out)?;
-
                     match self.stack.last() {
                         Some(is_para) => {
                             log::trace!("is_para: {:?}", is_para);
                             if *is_para {
+                                // Don't commit '}' yet for inline
+                                // attributes in a paragraph — let the
+                                // next word carry it so wrapping can
+                                // keep '}' together with what follows.
+                                self.push_word("}")?;
                                 self.prefix.pop();
                                 log::trace!("Prefix: {:?}", self.prefix);
+                            } else {
+                                self.push_word("}")?;
                             }
                         }
                         None => {
+                            self.push_word("}")?;
+                            self.commit_word(true, &mut out)?;
                             self.prefix.pop();
                             log::trace!("Prefix: {:?}", self.prefix);
                             self.need_blankline = true;

--- a/tests/wrap-long-line.in
+++ b/tests/wrap-long-line.in
@@ -5,3 +5,7 @@
 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
 A very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long line{ .with .attributes } that should be wrapped at 72 characters.
+
+> > A very very very very very very very very very very long line that should be wrapped between the closing `%` and the{% curly brace %}.
+
+> > > A very very very very very very very very long line that should not be wrapped between the dot and the closing { % curly brace % }.

--- a/tests/wrap-long-line.out
+++ b/tests/wrap-long-line.out
@@ -8,3 +8,11 @@ A very very very very very very very very very very very very very very
 very very very very very very very very very very very very very very
 very very very very very very very very very very long [line]{ .with
 .attributes } that should be wrapped at 72 characters.
+
+> > A very very very very very very very very very very long line that
+> > should be wrapped between the closing `%` and [the]{ % curly brace %
+> > }.
+
+> > > A very very very very very very very very long line that should
+> > > not be wrapped between the dot and the closing { % curly brace %
+> > > }.


### PR DESCRIPTION
- **test: add long-line wrapping test cases for blockquotes with inline attributes**
- **fix: defer closing brace commit in inline attributes for better wrapping**
