### PR TITLE
fix: prevent pointless wrap after list item marker

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -84,6 +84,11 @@ struct Writer<'a> {
     max_cols: usize,
     no_wrap: bool,
     table_data: Option<TableData>,
+    /// True after writing a list item marker, suppresses wrap until the first
+    /// content word is placed on the line.  Wrapping right after the marker is
+    /// pointless: the continuation prefix (e.g. "  ") has the same width as
+    /// the marker ("- "), so the next line offers no extra room.
+    list_item_start: bool,
 }
 
 impl<'a> Writer<'a> {
@@ -103,6 +108,7 @@ impl<'a> Writer<'a> {
             max_cols: config.max_cols,
             no_wrap: false,
             table_data: None,
+            list_item_start: false,
         }
     }
 
@@ -125,7 +131,11 @@ impl<'a> Writer<'a> {
         length += self.pending_word.width();
         let length = length;
 
-        if !self.no_wrap && length > self.max_cols && !self.pending_line.is_empty() {
+        if !self.no_wrap
+            && !self.list_item_start
+            && length > self.max_cols
+            && !self.pending_line.is_empty()
+        {
             self.wrap(out)?;
         } else if self.space_after_pending_word {
             self.pending_line.write_str(" ")?;
@@ -137,6 +147,7 @@ impl<'a> Writer<'a> {
         log::trace!("Pending line: {:?}", self.pending_line);
         self.pending_word.clear();
         self.space_after_pending_word = space_after;
+        self.list_item_start = false;
         Ok(())
     }
 
@@ -539,6 +550,7 @@ impl<'a> Writer<'a> {
                                     "task list items use TaskListItem container, not ListItem"
                                 ),
                             }
+                            self.list_item_start = true;
                         }
                         jotdown::Container::TaskListItem { checked } => {
                             self.blankline(&mut out)?;
@@ -551,6 +563,7 @@ impl<'a> Writer<'a> {
                             }
                             self.push_raw("] ")?;
                             self.prefix.push("      ".to_string());
+                            self.list_item_start = true;
                         }
                         jotdown::Container::DescriptionList => (),
                         jotdown::Container::DescriptionDetails => {

--- a/tests/wrap-long-line.in
+++ b/tests/wrap-long-line.in
@@ -9,3 +9,5 @@ A very very very very very very very very very very very very very very very ver
 > > A very very very very very very very very very very long line that should be wrapped between the closing `%` and the{% curly brace %}.
 
 > > > A very very very very very very very very long line that should not be wrapped between the dot and the closing { % curly brace % }.
+
+- 一个非常非常非常非常非常非常非常非常非常非常非常非常非常非常长的中文行。

--- a/tests/wrap-long-line.out
+++ b/tests/wrap-long-line.out
@@ -16,3 +16,5 @@ very very very very very very very very very very long [line]{ .with
 > > > A very very very very very very very very long line that should
 > > > not be wrapped between the dot and the closing { % curly brace %
 > > > }.
+
+- 一个非常非常非常非常非常非常非常非常非常非常非常非常非常非常长的中文行。


### PR DESCRIPTION
When the first word in a list item exceeds the line width, the
formatter would wrap right after the marker (e.g. "- "), putting
the marker alone on a line and the content on the next.  This is
pointless because the continuation prefix ("  ") has the same width
as the marker, so the next line offers no extra room.

Add a `list_item_start` flag that suppresses wrapping until the
first content word is placed on the same line as the marker.

This commit message is generated by LLM, it might be wrong.

Assisted-by: Claude Code:glm-5.1
Signed-off-by: Chen Linxuan <me@black-desk.cn>
