### PR TITLE
fix: reset no_wrap after table and prevent spurious wrap inside tables

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -135,6 +135,7 @@ impl<'a> Writer<'a> {
             && !self.list_item_start
             && length > self.max_cols
             && !self.pending_line.is_empty()
+            && self.table_data.is_none()
         {
             self.wrap(out)?;
         } else if self.space_after_pending_word {
@@ -737,6 +738,7 @@ impl<'a> Writer<'a> {
                                 let td = self.table_data.take().unwrap();
                                 self.render_table(td, &mut out)?;
                             }
+                            self.no_wrap = false;
                             self.need_blankline = true;
                         }
                         jotdown::Container::TableRow { head: _ } => {

--- a/tests/table.in
+++ b/tests/table.in
@@ -16,6 +16,8 @@
 | *table* | header |
 ^ A very long long long long long long long long *long long long long long* table caption
 
+A very long long long long long long long long {*long long long long long*} line after table
+
 > | This | formatter |
 > | should | handle |
 > |:-|-:|

--- a/tests/table.out
+++ b/tests/table.out
@@ -17,6 +17,9 @@
 ^ A very long long long long long long long long {*long long long long
   long*} table caption
 
+A very long long long long long long long long {*long long long long
+long*} line after table
+
 > | This      | formatter |
 > | should    |    handle |
 > |:----------|----------:|


### PR DESCRIPTION
The `no_wrap` flag was set to `true` by `Start(TableRow)` but never
reset when a table ended.  This caused paragraphs following a table to
never wrap, leaving long lines unbroken.

Reset `no_wrap` to `false` in the `End(Table)` handler so that
subsequent content wraps normally.

Additionally, `commit_word()` could enter the wrap branch while
`table_data` was still present.  Because `wrap()` is a no-op inside a
table, the space-separator `else if` branch was skipped, causing words
in table captions to be concatenated without spaces.  Add a
`table_data.is_none()` guard to the wrap condition so that spaces are
always added correctly while accumulating table content.

This commit message is generated by LLM, it might be wrong.

Assisted-by: Claude:glm-5.1
