### PR TITLE
fix: eliminate spurious zero-length str event before image_marker

### DIFF
--- a/src/parser/inline.rs
+++ b/src/parser/inline.rs
@@ -446,10 +446,11 @@ impl<'a> InlineParser<'a> {
                 // image_marker instead of replacing it (which would lose text).
                 let prev = &mut self.matches[opener_match_index - 1];
                 if prev.annot == "str" && prev.endpos >= opener_startpos - 1 {
-                    prev.endpos = opener_startpos.saturating_sub(2);
-                    if prev.endpos < prev.startpos {
+                    if prev.startpos == opener_startpos - 1 {
                         // Was only the '!' — remove entirely
                         self.matches[opener_match_index - 1].annot = "__remove__".to_string();
+                    } else {
+                        prev.endpos = opener_startpos - 2;
                     }
                 }
                 self.add_match(opener_startpos - 1, opener_startpos - 1, "image_marker");
@@ -542,9 +543,11 @@ impl<'a> InlineParser<'a> {
                         // image_marker instead of replacing it (which would lose text).
                         let prev = &mut self.matches[opener_match_index - 1];
                         if prev.annot == "str" && prev.endpos >= opener_startpos - 1 {
-                            prev.endpos = opener_startpos.saturating_sub(2);
-                            if prev.endpos < prev.startpos {
+                            if prev.startpos == opener_startpos - 1 {
+                                // Was only the '!' — remove entirely
                                 self.matches[opener_match_index - 1].annot = "__remove__".to_string();
+                            } else {
+                                prev.endpos = opener_startpos - 2;
                             }
                         }
                         self.add_match(opener_startpos - 1, opener_startpos - 1, "image_marker");

--- a/tests/parser_events_test.rs
+++ b/tests/parser_events_test.rs
@@ -200,16 +200,6 @@ fn main() {
         .filter_map(|e| e.ok())
         .collect();
 
-    // Cases to skip: our parser fixes djot.js bugs, so these differ from
-    // djot.js CLI output. Text before image markers is correctly emitted
-    // as a str event, but djot.js omits it.
-    let skip_cases: &[(&str, usize)] = &[
-        ("links_and_images.test", 1),
-        ("links_and_images.test", 16),
-        ("links_and_images.test", 18),
-        ("links_and_images.test", 26),
-    ];
-
     for entry in &entries {
         let file_name = entry.file_name().unwrap().to_str().unwrap().to_string();
         let content = std::fs::read_to_string(entry).unwrap();
@@ -217,10 +207,6 @@ fn main() {
 
         for (case_idx, input) in cases.into_iter().enumerate() {
             let name = format!("{}::case_{}", file_name, case_idx);
-            if skip_cases.contains(&(file_name.as_str(), case_idx)) {
-                trials.push(Trial::test(name, || Ok(())));
-                continue;
-            }
             let test_file = file_name.clone();
             trials.push(Trial::test(name, move || {
                 run_parser_event_test(&test_file, case_idx, &input)
@@ -232,12 +218,6 @@ fn main() {
         eprintln!("No test cases found in {}", test_dir.display());
     }
 
-    // Integration test files that hit the image-marker bug fixed in our parser
-    let skip_integration: &[&str] = &[
-        "links-and-images",
-        "wrap-inline-boundary",
-    ];
-
     // Also test integration .in/.out files
     let int_entries: Vec<_> = glob::glob("tests/*.in")
         .unwrap()
@@ -248,30 +228,20 @@ fn main() {
         let stem = in_path.file_stem().unwrap().to_str().unwrap().to_string();
         let in_content = std::fs::read_to_string(in_path).unwrap();
 
-        let skip = skip_integration.contains(&stem.as_str());
-
         let in_stem = stem.clone();
         let in_name = format!("integration::{}::in", stem);
         let in_content_clone = in_content.clone();
-        if skip {
-            trials.push(Trial::test(in_name, || Ok(())));
-        } else {
-            trials.push(Trial::test(in_name, move || {
-                run_parser_event_test(&format!("{}.in", in_stem), 0, &in_content_clone)
-            }));
-        }
+        trials.push(Trial::test(in_name, move || {
+            run_parser_event_test(&format!("{}.in", in_stem), 0, &in_content_clone)
+        }));
 
         let out_path = in_path.with_extension("out");
         if out_path.exists() {
             let out_content = std::fs::read_to_string(&out_path).unwrap();
             let out_name = format!("integration::{}::out", stem);
-            if skip {
-                trials.push(Trial::test(out_name, || Ok(())));
-            } else {
-                trials.push(Trial::test(out_name, move || {
-                    run_parser_event_test(&format!("{}.out", stem), 0, &out_content)
-                }));
-            }
+            trials.push(Trial::test(out_name, move || {
+                run_parser_event_test(&format!("{}.out", stem), 0, &out_content)
+            }));
         }
     }
 


### PR DESCRIPTION
When the parser encountered `![...]` at the start of a line (e.g.
`![](/url.png)`), the `!` character was batched into a str match by
the non-special-character path. The image fixup logic tried to trim
that str match using `saturating_sub(2)`, which left a zero-length
str(0, 0) behind because the boundary check used `<` instead of
comparing the match start against the `!` position directly.

Fix by checking whether the preceding str match covers only the `!`
(prev.startpos == opener_startpos - 1) and removing it entirely in
that case, otherwise truncating to preserve text before `!`.

Also update djot.js submodule to include the upstream fix for text
loss before inline image markers, and re-enable all previously skipped
parser event tests (4 links_and_images cases + 2 integration files).

This commit message is generated by LLM, it might be wrong.

Assisted-by: Claude:glm-5.1
