### PR TITLE
test: build djot.js in parser test preamble; require conformance in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
       id-token: write
       contents: write
 
+    # Fail hard if the djot.js conformance suite can't actually run (missing JS
+    # toolchain, missing submodule, failed build) instead of silently skipping.
+    # Guards against a future runner-image change that drops node/npm unnoticed.
+    env:
+      DJOTFMT_REQUIRE_CONFORMANCE: '1'
+
     runs-on: ubuntu-latest
     steps:
       - uses: black-desk/workflows/rust@master

--- a/tests/parser_events_test.rs
+++ b/tests/parser_events_test.rs
@@ -148,6 +148,166 @@ fn check_djot_available() -> bool {
         .unwrap_or(false)
 }
 
+/// Path to the pinned djot.js submodule, relative to the crate root (integration
+/// tests run with the crate root as their working directory).
+const DJOT_JS: &str = "third_party/djot.js";
+
+/// When set (to a non-empty, non-"0"/"false" value) the suite must actually run:
+/// any condition that would otherwise cause a silent skip (missing JS toolchain,
+/// missing submodule, or a failed build) instead fails the test binary. Set this
+/// in CI so a runner-image change — e.g. npm disappearing — surfaces as a red
+/// build instead of the conformance suite quietly vanishing.
+fn require_conformance() -> bool {
+    matches!(
+        std::env::var("DJOTFMT_REQUIRE_CONFORMANCE"),
+        Ok(v) if !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false")
+    )
+}
+
+/// Print an error and exit non-zero, failing the test run.
+fn fatal(msg: &str) -> ! {
+    eprintln!("error: {msg}.");
+    std::process::exit(1)
+}
+
+/// Ensure `third_party/djot.js/lib/cli.js` is built from the pinned submodule
+/// source before the suite runs. `lib/` is a gitignored build artifact
+/// (`tsc && webpack`), so it is absent on a fresh checkout and would otherwise
+/// make the whole suite skip silently. Building it here — its only consumer —
+/// keeps the formatter itself free of any JS toolchain requirement.
+fn ensure_djot_built() {
+    use std::path::Path;
+
+    let base = Path::new(DJOT_JS);
+
+    // Submodule not checked out (e.g. a shallow clone) — nothing to build; the
+    // suite skips via `check_djot_available`.
+    if !base.join("src").is_dir() {
+        if require_conformance() {
+            fatal(
+                "DJOTFMT_REQUIRE_CONFORMANCE is set but the djot.js submodule is \
+                 not checked out",
+            );
+        }
+        return;
+    }
+
+    let lib_cli = base.join("lib/cli.js");
+    if lib_cli.exists() && is_fresh(&lib_cli, &base.join("src")) {
+        return;
+    }
+
+    // No JS toolchain (or explicitly opted out) — leave the gap to
+    // `check_djot_available`, which skips the suite with a clear message.
+    if std::env::var_os("DJOTFMT_SKIP_JS_BUILD").is_some() || !have("node") || !have("npm") {
+        if require_conformance() {
+            let reason = if std::env::var_os("DJOTFMT_SKIP_JS_BUILD").is_some() {
+                "DJOTFMT_SKIP_JS_BUILD is set".to_string()
+            } else {
+                "node/npm is not available on PATH".to_string()
+            };
+            fatal(&format!(
+                "DJOTFMT_REQUIRE_CONFORMANCE is set but the djot.js reference build \
+                 cannot be produced ({reason})"
+            ));
+        }
+        eprintln!(
+            "note: djot.js lib/cli.js is missing or stale and no JS toolchain is \
+             available; parser conformance tests will be skipped. Build manually with \
+             `npm --prefix {DJOT_JS} ci && npm --prefix {DJOT_JS} run build`, or set \
+             DJOTFMT_SKIP_JS_BUILD=1 to silence this."
+        );
+        return;
+    }
+
+    eprintln!("note: building djot.js lib/ from the pinned submodule source...");
+
+    // `npm ci` installs exactly from the lockfile, but on non-macOS hosts it
+    // also rewrites yarn.lock to drop the macOS-only `fsevents` optional
+    // dependency. Snapshot and restore the lockfiles so the submodule working
+    // tree stays clean.
+    if !base.join("node_modules").is_dir() {
+        let snapshots = ["yarn.lock", "package-lock.json"]
+            .map(|name| (name, std::fs::read(base.join(name)).ok()));
+        npm(&["ci"], "install djot.js dependencies (locked)");
+        for (name, snapshot) in &snapshots {
+            if let Some(content) = snapshot {
+                let _ = std::fs::write(base.join(name), content);
+            }
+        }
+    }
+
+    npm(&["run", "build"], "build djot.js lib/ from the pinned source");
+}
+
+/// `true` iff `lib_cli` is at least as new as the newest file under `src_dir`.
+fn is_fresh(lib_cli: &std::path::Path, src_dir: &std::path::Path) -> bool {
+    let Some(lib_mtime) = mtime(lib_cli) else {
+        return false;
+    };
+    let mut fresh = true;
+    walk(src_dir, &mut |path| {
+        if let Some(t) = mtime(path) {
+            if t > lib_mtime {
+                fresh = false;
+            }
+        }
+    });
+    fresh
+}
+
+/// Probe whether a command is runnable by asking it for its version.
+fn have(cmd: &str) -> bool {
+    std::process::Command::new(cmd)
+        .arg("--version")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok()
+}
+
+/// Run an `npm` command inside the djot.js submodule, exiting the test binary
+/// (and thus failing the suite) on error.
+fn npm(args: &[&str], label: &str) {
+    let status = std::process::Command::new("npm")
+        .args(args)
+        .current_dir(DJOT_JS)
+        .status();
+    match status {
+        Ok(status) if status.success() => {}
+        Ok(status) => {
+            eprintln!(
+                "error: failed to {label} (`npm {}` exited with {status}).",
+                args.join(" ")
+            );
+            std::process::exit(1);
+        }
+        Err(err) => {
+            eprintln!("error: failed to {label}: cannot run `npm`: {err}.");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn mtime(path: &std::path::Path) -> Option<std::time::SystemTime> {
+    std::fs::metadata(path).ok()?.modified().ok()
+}
+
+fn walk(dir: &std::path::Path, f: &mut dyn FnMut(&std::path::Path)) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk(&path, f);
+        } else {
+            f(&path);
+        }
+    }
+}
+
 fn run_parser_event_test(
     test_file: &str,
     case_index: usize,
@@ -187,7 +347,19 @@ fn run_parser_event_test(
 fn main() {
     let args = Arguments::from_args();
 
+    // Build the djot.js reference CLI from the pinned submodule so the suite
+    // compares against the right artifacts instead of silently skipping on a
+    // fresh checkout. This is the only consumer of lib/cli.js, so the build
+    // lives here rather than in build.rs (the formatter itself stays JS-free).
+    ensure_djot_built();
+
     if !check_djot_available() {
+        if require_conformance() {
+            fatal(
+                "DJOTFMT_REQUIRE_CONFORMANCE is set but the djot.js CLI is unavailable \
+                 (lib/cli.js missing or node cannot run it)",
+            );
+        }
         eprintln!("SKIP: djot CLI not found. Install with: npm install -g @djot/djot");
         libtest_mimic::run(&args, vec![]).exit();
     }


### PR DESCRIPTION
## Problem

`parser_events_test` validates the Rust parser by comparing it against `third_party/djot.js/lib/cli.js`. That file is a **gitignored build artifact** (`tsc && webpack`), not committed source — so on a fresh checkout or after a `submodule update` it is absent. Consequences:

- **Locally**: the suite compared against a stale `lib/` built from an older djot.js, producing 4 spurious `endpos` failures (off-by-one around inline image markers, where the pinned djot.js commit `c7760b9` "Fix text loss before inline image marker" had changed behavior).
- **In CI**: the `rust` job had no JS toolchain wired in, so the suite's availability check returned false and **the entire 364-case conformance suite was silently skipped** — CI was green regardless of parser correctness.

## Fix

- **Build djot.js in the test preamble.** `parser_events_test::main()` now builds `lib/cli.js` from the pinned submodule source before running trials. It's the *only* consumer of `lib/cli.js`, so the build lives with the test instead of in `build.rs` — the formatter (`cargo build` / `cargo install` / `cargo check` / IDE) stays entirely JS-free. A fresh `lib/` short-circuits; otherwise `npm ci` + `npm run build`, with the lockfiles snapshotted/restored so `npm ci` doesn't dirty the submodule (it drops the macOS-only `fsevents` entry from `yarn.lock` on Linux).
- **`DJOTFMT_REQUIRE_CONFORMANCE` gate.** When set, any condition that would skip the suite (missing node/npm, missing submodule, or `DJOTFMT_SKIP_JS_BUILD`) fails the test binary hard instead of skipping. This turns "npm disappeared from the runner image" into a red build rather than a silent loss of coverage.
- **Wire it into CI.** `env: DJOTFMT_REQUIRE_CONFORMANCE: '1'` on the `rust` job (job-level env is inherited by the `cargo llvm-cov` run inside `black-desk/workflows/rust`). Since that job already checks out submodules recursively and ubuntu-latest ships node, the suite now actually runs all 364 cases.

## Verification

| Scenario | Result |
|---|---|
| Fresh checkout (no `node_modules`, no `lib`) → test builds djot.js | 364 passed |
| Normal run, `lib` fresh | 364 passed (no rebuild) |
| `cargo build` (formatter) | unaffected, no JS toolchain needed |
| `fmt_test` | 92 passed (unaffected) |
| `DJOTFMT_REQUIRE_CONFORMANCE=1` + no node on PATH + missing lib | **exit 1** (hard fail) |
| same, without the env var | exit 0, graceful skip (local-friendly) |
| `DJOTFMT_SKIP_JS_BUILD=1` + `DJOTFMT_REQUIRE_CONFORMANCE=1` | **exit 1** (require wins) |
| Submodule lockfiles after build | clean (snapshot/restore) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
