### PR TITLE
fix: resolve clippy 1.95 lints failing CI

### DIFF
--- a/src/parser/block.rs
+++ b/src/parser/block.rs
@@ -59,6 +59,8 @@ enum ContentType {
     ListItem,
 }
 
+#[derive(Default)]
+#[allow(dead_code)]
 struct ContainerExtra {
     level: usize,
     close_pattern: Option<Regex>,
@@ -73,26 +75,6 @@ struct ContainerExtra {
     status: String,
     startpos: usize,
     slices: Vec<(usize, usize)>,
-}
-
-impl Default for ContainerExtra {
-    fn default() -> Self {
-        ContainerExtra {
-            level: 0,
-            close_pattern: None,
-            end_fence_startpos: 0,
-            end_fence_endpos: 0,
-            styles: Vec::new(),
-            indent: 0,
-            note_label: String::new(),
-            key: String::new(),
-            columns: 0,
-            colons: 0,
-            status: String::new(),
-            startpos: 0,
-            slices: Vec::new(),
-        }
-    }
 }
 
 struct Container<'a> {
@@ -235,7 +217,7 @@ impl<'a> EventParser<'a> {
         });
     }
 
-    fn tip(&self) -> Option<&Container> {
+    fn tip(&self) -> Option<&Container<'_>> {
         self.containers.last()
     }
 
@@ -388,7 +370,7 @@ impl<'a> EventParser<'a> {
 
     fn try_footnote(&mut self) -> bool {
         if let Some((sp, ep, caps)) = self.find(&PATT_FOOTNOTE_START) {
-            let label = caps.get(0).map(|s| s.as_str()).unwrap_or("");
+            let label = caps.first().map(|s| s.as_str()).unwrap_or("");
             self.add_container(Container {
                 name: "footnote".to_string(),
                 ctype: ContentType::Block,
@@ -417,7 +399,7 @@ impl<'a> EventParser<'a> {
 
     fn try_reference_definition(&mut self) -> bool {
         if let Some((sp, _ep, caps)) = self.find(&PATT_REFERENCE_DEF) {
-            let label = caps.get(0).map(|s| s.as_str()).unwrap_or("");
+            let label = caps.first().map(|s| s.as_str()).unwrap_or("");
             let value = caps.get(1).map(|s| s.trim_start()).unwrap_or("");
             self.add_container(Container {
                 name: "reference_definition".to_string(),
@@ -508,7 +490,7 @@ impl<'a> EventParser<'a> {
             });
             let mut annot = "+list".to_string();
             for style in &styles {
-                annot.push_str("|");
+                annot.push('|');
                 annot.push_str(style);
             }
             self.add_match(sp, ep - 1, &annot);
@@ -569,7 +551,7 @@ impl<'a> EventParser<'a> {
             });
             let mut annot = "+list_item".to_string();
             for style in &styles {
-                annot.push_str("|");
+                annot.push('|');
                 annot.push_str(style);
             }
             self.add_match(sp, ep - 1, &annot);
@@ -593,7 +575,7 @@ impl<'a> EventParser<'a> {
     }
 
     fn try_table(&mut self) -> bool {
-        if let Some((sp, ep, caps)) = self.find(&PATT_TABLE_ROW) {
+        if let Some((sp, _ep, caps)) = self.find(&PATT_TABLE_ROW) {
             let rawrow = &caps[0];
             self.add_container(Container {
                 name: "table".to_string(),
@@ -841,9 +823,10 @@ impl<'a> EventParser<'a> {
                 find::find_pos(self.subject, &PATT_NEXT_BAR_OR_TICKS, self.pos, Some(ep))
             {
                 let nextbar = mep;
-                if self.subject.as_bytes()[nextbar] == b'`' || inline_parser.verbatim > 0 {
-                    inline_parser.feed(self.pos, nextbar);
-                } else if nextbar > 0 && self.subject.as_bytes()[nextbar - 1] == b'\\' {
+                if self.subject.as_bytes()[nextbar] == b'`'
+                    || inline_parser.verbatim > 0
+                    || (nextbar > 0 && self.subject.as_bytes()[nextbar - 1] == b'\\')
+                {
                     inline_parser.feed(self.pos, nextbar);
                 } else {
                     inline_parser.feed(self.pos, nextbar - 1);
@@ -1097,10 +1080,8 @@ impl<'a> EventParser<'a> {
             }
         }
         // type: ListItem specs
-        if spec_type == ContentType::ListItem {
-            if self.try_list_item() {
-                return Some(());
-            }
+        if spec_type == ContentType::ListItem && self.try_list_item() {
+            return Some(());
         }
         None
     }

--- a/src/parser/inline.rs
+++ b/src/parser/inline.rs
@@ -296,7 +296,7 @@ impl<'a> InlineParser<'a> {
 
         let lastmatch = self.matches.last();
         let has_open_marker = lastmatch.map(|m| m.annot == "open_marker").unwrap_or(false);
-        let has_close_marker = pos + 1 <= endpos && cp(subject, pos + 1) == C_RIGHT_BRACE;
+        let has_close_marker = pos < endpos && cp(subject, pos + 1) == C_RIGHT_BRACE;
 
         let mut endcloser = pos;
         let mut startopener = pos;
@@ -308,7 +308,7 @@ impl<'a> InlineParser<'a> {
             can_close = false;
         }
         if !has_open_marker && has_close_marker {
-            endcloser = if pos + 1 <= endpos { pos + 1 } else { pos };
+            endcloser = if pos < endpos { pos + 1 } else { pos };
             can_close = true;
             can_open = false;
         }
@@ -409,11 +409,7 @@ impl<'a> InlineParser<'a> {
         let subject = self.subject;
 
         // Find the [ openers
-        let ob_idx = self.openers.iter().position(|(k, _)| *k == "[");
-        if ob_idx.is_none() {
-            return None;
-        }
-        let ob_idx = ob_idx.unwrap();
+        let ob_idx = self.openers.iter().position(|(k, _)| *k == "[")?;
 
         if self.openers[ob_idx].1.is_empty() {
             return None;
@@ -474,7 +470,7 @@ impl<'a> InlineParser<'a> {
             self.add_match(pos, pos, "-reference");
             self.clear_openers(opener_startpos, pos);
             return Some(pos + 1);
-        } else if pos + 1 <= endpos && cp(subject, pos + 1) == C_LEFT_BRACKET {
+        } else if pos < endpos && cp(subject, pos + 1) == C_LEFT_BRACKET {
             self.openers[ob_idx].1[last_idx].annot = Some("reference_link".to_string());
             self.add_match(pos, pos, "str");
             self.openers[ob_idx].1[last_idx].sub_match_index = self.matches.len() - 1;
@@ -484,7 +480,7 @@ impl<'a> InlineParser<'a> {
             let sp = self.openers[ob_idx].1[last_idx].startpos + 1;
             self.clear_openers(sp, pos - 1);
             return Some(pos + 2);
-        } else if pos + 1 <= endpos && cp(subject, pos + 1) == C_LEFT_PAREN {
+        } else if pos < endpos && cp(subject, pos + 1) == C_LEFT_PAREN {
             // clear ( openers
             if let Some(parens_idx) = self.openers.iter_mut().position(|(k, _)| *k == "(") {
                 self.openers[parens_idx].1.clear();
@@ -499,7 +495,7 @@ impl<'a> InlineParser<'a> {
             let sp = self.openers[ob_idx].1[last_idx].startpos + 1;
             self.clear_openers(sp, pos - 1);
             return Some(pos + 2);
-        } else if pos + 1 <= endpos && cp(subject, pos + 1) == C_LEFT_BRACE {
+        } else if pos < endpos && cp(subject, pos + 1) == C_LEFT_BRACE {
             // bracketed span
             self.add_match_at(opener_match_index, opener_startpos, opener_endpos, "+span");
             self.add_match(pos, pos, "-span");
@@ -639,8 +635,8 @@ impl<'a> InlineParser<'a> {
             return Some(pos + 2);
         }
 
-        let all_em = hyphens % 3 == 0;
-        let all_en = hyphens % 2 == 0;
+        let all_em = hyphens.is_multiple_of(3);
+        let all_en = hyphens.is_multiple_of(2);
         let mut p = pos;
         while hyphens > 0 {
             if all_em {
@@ -651,7 +647,7 @@ impl<'a> InlineParser<'a> {
                 self.add_match(p, p + 1, "en_dash");
                 p += 2;
                 hyphens -= 2;
-            } else if hyphens >= 3 && (hyphens % 2 != 0 || hyphens > 4) {
+            } else if hyphens >= 3 && (!hyphens.is_multiple_of(2) || hyphens > 4) {
                 self.add_match(p, p + 2, "em_dash");
                 p += 3;
                 hyphens -= 3;
@@ -733,7 +729,7 @@ impl<'a> InlineParser<'a> {
             let c = cp(subject, pos);
 
             if c == C_CR || c == C_LF {
-                if c == C_CR && cp(subject, pos + 1) == C_LF && pos + 1 <= endpos {
+                if c == C_CR && cp(subject, pos + 1) == C_LF && pos < endpos {
                     self.add_match(pos, pos + 1, "soft_break");
                     pos += 2;
                 } else {
@@ -750,14 +746,24 @@ impl<'a> InlineParser<'a> {
                             // check for raw attribute
                             let has_raw =
                                 find::find(subject, &PATT_RAW_ATTRIBUTE, endchar + 1, Some(endpos));
-                            if has_raw.is_some() && self.verbatim_type == "verbatim" {
-                                let (m2_start, m2_end, _) = has_raw.unwrap();
-                                self.add_match(pos, endchar, &format!("-{}", self.verbatim_type));
-                                self.add_match(m2_start, m2_end, "raw_format");
-                                pos = m2_end + 1;
-                            } else {
-                                self.add_match(pos, endchar, &format!("-{}", self.verbatim_type));
-                                pos = endchar + 1;
+                            match has_raw {
+                                Some((m2_start, m2_end, _)) if self.verbatim_type == "verbatim" => {
+                                    self.add_match(
+                                        pos,
+                                        endchar,
+                                        &format!("-{}", self.verbatim_type),
+                                    );
+                                    self.add_match(m2_start, m2_end, "raw_format");
+                                    pos = m2_end + 1;
+                                }
+                                _ => {
+                                    self.add_match(
+                                        pos,
+                                        endchar,
+                                        &format!("-{}", self.verbatim_type),
+                                    );
+                                    pos = endchar + 1;
+                                }
                             }
                             self.verbatim = 0;
                             self.verbatim_type = "verbatim".to_string();
@@ -845,7 +851,7 @@ impl<'a> InlineParser<'a> {
                             self.add_match(pos, pos, "escape");
                             self.add_match(m_start, m_end, "str");
                             Some(m_end + 1)
-                        } else if pos + 1 <= endpos && cp(subject, pos + 1) == C_SPACE {
+                        } else if pos < endpos && cp(subject, pos + 1) == C_SPACE {
                             self.add_match(pos, pos, "escape");
                             self.add_match(pos + 1, pos + 1, "non_breaking_space");
                             Some(pos + 2)
@@ -922,22 +928,12 @@ impl<'a> InlineParser<'a> {
                     C_ASTERISK => {
                         Some(self.between_matched("*", "strong", "str", |_s, _p| true, pos, endpos))
                     }
-                    C_PLUS => Some(self.between_matched(
-                        "+",
-                        "insert",
-                        "str",
-                        |s, p| has_brace(s, p),
-                        pos,
-                        endpos,
-                    )),
-                    C_EQUALS => Some(self.between_matched(
-                        "=",
-                        "mark",
-                        "str",
-                        |s, p| has_brace(s, p),
-                        pos,
-                        endpos,
-                    )),
+                    C_PLUS => {
+                        Some(self.between_matched("+", "insert", "str", has_brace, pos, endpos))
+                    }
+                    C_EQUALS => {
+                        Some(self.between_matched("=", "mark", "str", has_brace, pos, endpos))
+                    }
                     C_SINGLE_QUOTE => Some(self.between_matched(
                         "'",
                         "single_quoted",

--- a/tests/parser_events_test.rs
+++ b/tests/parser_events_test.rs
@@ -43,9 +43,7 @@ fn build_byte_to_utf16_map(input: &str) -> Vec<usize> {
         let utf8_len = c.len_utf8();
         let utf16_len = c.len_utf16();
         let last_utf16 = utf16_pos + utf16_len - 1;
-        for b in byte_pos..byte_pos + utf8_len {
-            map[b] = last_utf16;
-        }
+        map[byte_pos..byte_pos + utf8_len].fill(last_utf16);
         byte_pos += utf8_len;
         utf16_pos += utf16_len;
     }


### PR DESCRIPTION
CI runs `cargo clippy -- -D warnings` with the latest stable toolchain. Rust 1.95 / clippy 0.1.95 introduced several new lints that the codebase violates, causing all dependabot PRs to fail (25 errors total).

## Changes

**`src/parser/inline.rs` (14 fixes)**
- `int_plus_one`: rewrite `pos + 1 <= endpos` as `pos < endpos` (×7)
- `question_mark`: collapse `is_none` + `unwrap` into `?`
- `manual_is_multiple_of`: use `.is_multiple_of(N)` instead of `% N == 0` (×3)
- `unnecessary_unwrap`: replace `is_some` + `unwrap` with `match` (let-chains unavailable outside Rust 2024 edition)
- `redundant_closure`: pass function reference directly instead of wrapping in a closure (×2)

**`src/parser/block.rs` (10 fixes)**
- `mismatched_lifetime_syntaxes`: add explicit `<'_>` to `&Container`
- `get_first`: use `caps.first()` instead of `caps.get(0)` (×2)
- `single_char_add_str`: use `push('|')` instead of `push_str("|")` (×2)
- `if_same_then_else`: merge identical if/else-if branches
- `collapsible_if`: flatten nested if
- `derivable_impls` + `dead_code`: replace manual `impl Default` with `#[derive(Default)]`, add `#[allow(dead_code)]`

**`tests/parser_events_test.rs` (1 fix)**
- `needless_range_loop`: replace indexed for-loop with `slice::fill`

## Verification
- `cargo clippy --all-features --workspace --all-targets -- -D warnings` — clean
- `cargo test --release` — 366 passed, 0 failed